### PR TITLE
#8. Add a simple currency converter.

### DIFF
--- a/src/QuickInfo/Processors/Converters/Currency.cs
+++ b/src/QuickInfo/Processors/Converters/Currency.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace QuickInfo
+{        
+    public static class Currency
+    {
+        private const string Endpoint = @"https://api.fixer.io/latest";
+
+        private static readonly MemoryCacheOptions _options = new MemoryCacheOptions();
+        private static readonly MemoryCache _cache = new MemoryCache(_options);
+        private static readonly HttpClient _httpClient = new HttpClient();
+
+        public static double Convert(string from, string to, double value)
+        {
+            var pair = new CurrencyPair(from, to);
+            var rate = _cache.GetOrCreate(
+                pair,
+                e => 
+                {
+                    e.SetAbsoluteExpiration(TimeSpan.FromDays(1));
+                    return GetRate(from, to);
+                });
+
+            return rate * value;
+        }
+
+        private static double GetRate(string from, string to)
+        {
+            var endpoint = $"{Endpoint}?base={from.ToUpper()}&symbols={to.ToUpper()}";
+            var result = _httpClient.GetStringAsync(endpoint).Result;
+            var rate = JsonConvert.DeserializeObject<CurrencyRate>(result);
+
+            return rate.Rates.FirstOrDefault().Value;
+        }
+    }
+
+    #region Exchange currencies stuff
+    struct CurrencyPair
+    {
+        public CurrencyPair(string from, string to)
+        {
+            From = from;
+            To = to;
+        }
+
+        public string From { get; set; }
+        public string To { get; set; }
+    }
+
+    class CurrencyRate
+    {
+        [JsonProperty(PropertyName = "rates")]
+        public Dictionary<string, double> Rates { get; set; }
+    }
+    #endregion
+}

--- a/src/QuickInfo/Processors/Converters/Units/Units.cs
+++ b/src/QuickInfo/Processors/Converters/Units/Units.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Reflection;
 
 namespace QuickInfo
 {
@@ -52,6 +51,11 @@ namespace QuickInfo
         public static readonly Unit Mpg = new Unit("mpg", "miles/gallon");
         public static readonly Unit LitersPer100Km = new Unit("liters/100km", "l/100km");
 
+        public static readonly Unit EUR = new Unit("EUR", "Euro", "€");
+        public static readonly Unit USD = new Unit("USD", "United States Dollar", "$");
+        public static readonly Unit RUB = new Unit("RUB", "Russia ruble", "₽");
+        public static readonly Unit CZK = new Unit("CZK", "Czech Republic Koruna", "Kč");
+        
         public static readonly Conversion[] Conversions =
         {
             new Conversion(Pound, Kilogram, p => p * 0.45359237),
@@ -126,6 +130,19 @@ namespace QuickInfo
 
             new Conversion(Mpg, LitersPer100Km, p => 235.214583084785 / p),
             new Conversion(LitersPer100Km, Mpg, p => 235.214583084785 / p),
+
+            new Conversion(EUR, USD, p => Currency.Convert("EUR", "USD", p)),
+            new Conversion(EUR, RUB, p => Currency.Convert("EUR", "RUB", p)),
+            new Conversion(EUR, CZK, p => Currency.Convert("EUR", "CZK", p)),
+            new Conversion(USD, EUR, p => Currency.Convert("USD", "EUR", p)),
+            new Conversion(USD, RUB, p => Currency.Convert("USD", "RUB", p)),
+            new Conversion(USD, CZK, p => Currency.Convert("USD", "CZK", p)),
+            new Conversion(RUB, EUR, p => Currency.Convert("RUB", "EUR", p)),
+            new Conversion(RUB, USD, p => Currency.Convert("RUB", "USD", p)),
+            new Conversion(RUB, CZK, p => Currency.Convert("RUB", "CZK", p)),
+            new Conversion(CZK, EUR, p => Currency.Convert("CZK", "EUR", p)),
+            new Conversion(CZK, USD, p => Currency.Convert("CZK", "USD", p)),
+            new Conversion(CZK, RUB, p => Currency.Convert("CZK", "RUB", p))
         };
 
         private static Unit[] allUnits = null;


### PR DESCRIPTION
Hi @KirillOsenkov 
I've added a simple currency converter.
I used the Unit conversion infrastructure as you advised.
So now it looks pretty good. But the solution is not so flexible because we need to create a new two conversation items for each currency pair. 
However I don't think that we have to add as much as possible currencies. It's out of scope of project in my opinion.
Meantime, QuickInfo supports the following currencies:
- USD
- EUR
- RUB
- CZK

If you need something else, you can add a new one without any problems.
On the whole I'd like you to merge my PR soon. 

Thank you in advance. 