### PR TITLE
Adds support for custom formatting of Conversions

### DIFF
--- a/src/QuickInfo/Processors/Converters/Units/Conversion.cs
+++ b/src/QuickInfo/Processors/Converters/Units/Conversion.cs
@@ -7,12 +7,18 @@ namespace QuickInfo
         public Unit From { get; set; }
         public Unit To { get; set; }
         public Func<double, double> Converter { get; set; }
+        public string Format { get; set; }
 
-        public Conversion(Unit from, Unit to, Func<double, double> converter)
+        public Conversion(Unit from, Unit to, Func<double, double> converter, string format)
         {
             From = from;
             To = to;
             Converter = converter;
+            Format = format;
+        }
+
+        public Conversion(Unit from, Unit to, Func<double, double> converter) : this(from, to, converter, String.Empty)
+        {
         }
     }
 }

--- a/src/QuickInfo/Processors/Converters/Units/UnitConverter.cs
+++ b/src/QuickInfo/Processors/Converters/Units/UnitConverter.cs
@@ -213,7 +213,7 @@ namespace QuickInfo
 
         private string GetResult(double value, Conversion conversion)
         {
-            return DivClass($"{value} {conversion.From.ToString()} = {conversion.Converter(value)} {conversion.To.ToString()}", "fixed");
+            return DivClass($"{value} {conversion.From.ToString()} = {conversion.Converter(value).ToString(conversion.Format)} {conversion.To.ToString()}", "fixed");
         }
     }
 }

--- a/src/QuickInfo/Processors/Converters/Units/Units.cs
+++ b/src/QuickInfo/Processors/Converters/Units/Units.cs
@@ -91,10 +91,10 @@ namespace QuickInfo
             new Conversion(Knot, Kmh, p => p * 1.852),
             new Conversion(Kmh, Knot, p => p / 1.852),
 
-            new Conversion(Fahrenheit, Celsius, p => (p - 32) * 5 / 9),
-            new Conversion(Celsius, Fahrenheit, p => p * 9 / 5 + 32),
-            new Conversion(Kelvin, Celsius, p => p - 273.15),
-            new Conversion(Celsius, Kelvin, p => p + 273.15),
+            new Conversion(Fahrenheit, Celsius, p => (p - 32) * 5 / 9, "f1"),
+            new Conversion(Celsius, Fahrenheit, p => p * 9 / 5 + 32, "f1"),
+            new Conversion(Kelvin, Celsius, p => p - 273.15, "f2"),
+            new Conversion(Celsius, Kelvin, p => p + 273.15, "f2"),
 
             new Conversion(Gallon, Liter, p => p * 3.78541178),
             new Conversion(Liter, Gallon, p => p / 3.78541178),
@@ -131,12 +131,12 @@ namespace QuickInfo
             new Conversion(Mpg, LitersPer100Km, p => 235.214583084785 / p),
             new Conversion(LitersPer100Km, Mpg, p => 235.214583084785 / p),
 
-            new Conversion(EUR, USD, p => Currency.Convert("EUR", "USD", p)),
-            new Conversion(USD, EUR, p => Currency.Convert("USD", "EUR", p)),
-            new Conversion(EUR, RUB, p => Currency.Convert("EUR", "RUB", p)),
-            new Conversion(RUB, EUR, p => Currency.Convert("RUB", "EUR", p)),
-            new Conversion(EUR, CZK, p => Currency.Convert("EUR", "CZK", p)),
-            new Conversion(CZK, EUR, p => Currency.Convert("CZK", "EUR", p)),
+            new Conversion(EUR, USD, p => Currency.Convert("EUR", "USD", p), "n2"),
+            new Conversion(USD, EUR, p => Currency.Convert("USD", "EUR", p), "n2"),
+            new Conversion(EUR, RUB, p => Currency.Convert("EUR", "RUB", p), "n2"),
+            new Conversion(RUB, EUR, p => Currency.Convert("RUB", "EUR", p), "n2"),
+            new Conversion(EUR, CZK, p => Currency.Convert("EUR", "CZK", p), "n2"),
+            new Conversion(CZK, EUR, p => Currency.Convert("CZK", "EUR", p), "n2"),
         };
 
         private static Unit[] allUnits = null;

--- a/src/QuickInfo/Processors/Converters/Units/Units.cs
+++ b/src/QuickInfo/Processors/Converters/Units/Units.cs
@@ -91,8 +91,8 @@ namespace QuickInfo
             new Conversion(Knot, Kmh, p => p * 1.852),
             new Conversion(Kmh, Knot, p => p / 1.852),
 
-            new Conversion(Fahrenheit, Celsius, p => (p - 32) * 5 / 9, "f1"),
-            new Conversion(Celsius, Fahrenheit, p => p * 9 / 5 + 32, "f1"),
+            new Conversion(Fahrenheit, Celsius, p => (p - 32) * 5 / 9, "f2"),
+            new Conversion(Celsius, Fahrenheit, p => p * 9 / 5 + 32, "f2"),
             new Conversion(Kelvin, Celsius, p => p - 273.15, "f2"),
             new Conversion(Celsius, Kelvin, p => p + 273.15, "f2"),
 


### PR DESCRIPTION
Adds support for [format string](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings) in printing conversion result.
Implements precision of two decimal digits for temperature and currency conversions:

currently:
70 f = 21.1111111111111 c
20 USD = 16.0772 EUR

proposed:
70 f = 21.1 c
20 USD = 16.08 EUR