### PR TITLE
Update Ecoji and allow trailing space to encode

### DIFF
--- a/src/QuickInfo/Processors/Ecoji.cs
+++ b/src/QuickInfo/Processors/Ecoji.cs
@@ -8,11 +8,6 @@ namespace QuickInfo
 {
     public sealed class EcojiEncoder : IProcessor
     {
-        private readonly HashSet<string> triggers = new HashSet<string>
-        {
-            "ecoji"
-        };
-
         public object GetResult(Query query)
         {
             if (query.IsHelp)
@@ -24,7 +19,7 @@ namespace QuickInfo
                 );
             }
 
-            var input = query.OriginalInput.Trim();
+            var input = query.OriginalInput.TrimStart();
             if (input.StartsWith("ecoji "))
             {
                 var text = input.Substring(6);
@@ -55,7 +50,7 @@ namespace QuickInfo
         {
             try
             {
-                return Ecoji.Decode(text, Encoding.UTF8);
+                return Ecoji.DecodeUtf8(text);
             }
             catch
             {

--- a/src/QuickInfo/QuickInfo.csproj
+++ b/src/QuickInfo/QuickInfo.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ecoji" Version="1.0.0" />
+    <PackageReference Include="Ecoji" Version="1.2.1" />
     <PackageReference Include="GuiLabs.MathParser" Version="1.0.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />

--- a/src/QuickInfoWeb/QuickInfoWeb.csproj
+++ b/src/QuickInfoWeb/QuickInfoWeb.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ecoji" Version="1.0.0" />
     <PackageReference Include="GuiLabs.MathParser" Version="1.0.9" />
     <PackageReference Include="UnicodeInformation" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
The update fixes a minor padding bug in the initial 1.0.0 release of Ecoji.

Use `Ecoji.DecodeUtf8`, drop unnecessary `PackageReference`, and remove unused `triggers` to avoid the alloc.