### PR TITLE
Use CIEDE2000 as color distance

### DIFF
--- a/src/QuickInfo/QuickInfo.csproj
+++ b/src/QuickInfo/QuickInfo.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Colourful" Version="2.0.5" />
     <PackageReference Include="Ecoji" Version="1.2.1" />
     <PackageReference Include="GuiLabs.MathParser" Version="1.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
Use CIEDE2000 color distance instead of the cartesian distance in RGB space to find closest colors.
See https://en.wikipedia.org/wiki/Color_difference#CIEDE2000