### PR TITLE
Update Colourful package to version 3.0.0

### DIFF
--- a/src/QuickInfo/Processors/Color.cs
+++ b/src/QuickInfo/Processors/Color.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Colourful;
-using Colourful.Conversion;
-using Colourful.Difference;
 using static QuickInfo.NodeFactory;
 
 namespace QuickInfo
@@ -241,7 +239,7 @@ namespace QuickInfo
             return colorMapByDistance.Select(t => t.Item1);
         }
 
-        private static readonly ColourfulConverter converter = new ColourfulConverter();
+        private static readonly IColorConverter<RGBColor, LabColor> converter = new ConverterBuilder().FromRGB().ToLab(Illuminants.D65).Build();
 
         private static readonly CIEDE2000ColorDifference difference = new CIEDE2000ColorDifference();
 
@@ -249,7 +247,7 @@ namespace QuickInfo
         /// See https://en.wikipedia.org/wiki/CIELAB_color_space
         /// </summary>
         private static LabColor ToLabColor(int r, int g, int b) =>
-            converter.ToLab(new RGBColor((double) r / 255, (double) g / 255, (double) b / 255));
+            converter.Convert(new RGBColor((double) r / 255, (double) g / 255, (double) b / 255));
 
         /// <summary>
         /// Distance between colors closely matching human perception of colors.

--- a/src/QuickInfo/Processors/Color.cs
+++ b/src/QuickInfo/Processors/Color.cs
@@ -239,7 +239,7 @@ namespace QuickInfo
             return colorMapByDistance.Select(t => t.Item1);
         }
 
-        private static readonly IColorConverter<RGBColor, LabColor> converter = new ConverterBuilder().FromRGB().ToLab(Illuminants.D65).Build();
+        private static readonly IColorConverter<RGBColor, LabColor> converter = new ConverterBuilder().FromRGB().ToLab().Build();
 
         private static readonly CIEDE2000ColorDifference difference = new CIEDE2000ColorDifference();
 

--- a/src/QuickInfo/QuickInfo.csproj
+++ b/src/QuickInfo/QuickInfo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Colourful" Version="2.0.5" />
+    <PackageReference Include="Colourful" Version="3.0.0" />
     <PackageReference Include="Ecoji" Version="1.2.1" />
     <PackageReference Include="GuiLabs.MathParser" Version="1.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
I released a [new major version of the Colourful library](https://github.com/tompazourek/Colourful/releases/tag/3.0.0) (PR [#95](https://github.com/tompazourek/Colourful/pull/95)) and thought I'd try integrating it in some of the projects that use it -- e.g. QuickInfo here.

During my manual tests, the "Closest named colors" seems to still work great after the update 😊

It should have better performance than version 2.0.5 that's currently there, but performance probably isn't a very important thing in QuickInfo. Anyway, hope you find the update useful.