### PR TITLE
Fix tests by updating the UnicodeInformation package to version 2.6.0

### DIFF
--- a/src/QuickInfo/QuickInfo.csproj
+++ b/src/QuickInfo/QuickInfo.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Ecoji" Version="1.2.1" />
     <PackageReference Include="GuiLabs.MathParser" Version="1.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="UnicodeInformation" Version="2.5.0" />
+    <PackageReference Include="UnicodeInformation" Version="2.6.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/QuickInfoWeb/QuickInfoWeb.csproj
+++ b/src/QuickInfoWeb/QuickInfoWeb.csproj
@@ -15,11 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GuiLabs.MathParser" Version="1.0.9" />
-    <PackageReference Include="UnicodeInformation" Version="2.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This makes the tests pass. With version 2.5.0, the tests would fail with the following exception:
> System.TypeInitializationException
> The type initializer for 'System.Unicode.UnicodeInfo' threw an exception.
> at System.Unicode.UnicodeInfo.GetBlocks()
> at QuickInfo.Unicode.BuildUnicodeList() in QuickInfo\src\QuickInfo\Processors\Unicode.cs:line 194
> at QuickInfo.Unicode..ctor() in QuickInfo\src\QuickInfo\Processors\Unicode.cs:line 22
> at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
> 
> System.IO.EndOfStreamException
> Attempted to read past the end of the stream.
>    at System.Unicode.UnicodeData.ReadUnicodeCharacterDataEntry(BinaryReader reader, Byte[] nameBuffer, UnicodeCharacterData& value)
>    at System.Unicode.UnicodeData.ReadFromStream(Stream stream)
>    at System.Unicode.UnicodeData.ReadFromResources()
>    at System.Unicode.UnicodeInfo..cctor()
9262eb