### PR TITLE
Properly handle whitespaces in queries

### DIFF
--- a/src/QuickInfo.Tests/IntegrationTests.cs
+++ b/src/QuickInfo.Tests/IntegrationTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace QuickInfo.Tests
+{
+    public class IntegrationTests
+    {
+        [Theory]
+        [InlineData("a",         @"<div class=""mainAnswerText"">LATIN SMALL LETTER A</div>")]
+        [InlineData("%C3%A9",    @"<div class=""mainAnswerText"">LATIN SMALL LETTER E WITH ACUTE</div>")]
+        [InlineData("%E2%80%AF", @"<div class=""mainAnswerText"">NARROW NO-BREAK SPACE</div>")]
+        public async Task TestQuery(string query, string output)
+        {
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            var response = await client.GetStringAsync($"api/Answers?query={query}");
+
+            Assert.Contains(output, response);
+        }
+    }
+}

--- a/src/QuickInfo.Tests/QuickInfo.Tests.csproj
+++ b/src/QuickInfo.Tests/QuickInfo.Tests.csproj
@@ -1,21 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\QuickInfoWeb\QuickInfoWeb.csproj" />
-    <ProjectReference Include="..\QuickInfo\QuickInfo.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/QuickInfo.Tests/QuickInfo.Tests.csproj
+++ b/src/QuickInfo.Tests/QuickInfo.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />

--- a/src/QuickInfoWeb/Controllers/AnswersController.cs
+++ b/src/QuickInfoWeb/Controllers/AnswersController.cs
@@ -14,6 +14,9 @@ namespace QuickInfo.Controllers
         [HttpGet]
         public string Get([FromQuery] string query)
         {
+            // See [Parameters binding removes whitespace](https://github.com/dotnet/aspnetcore/issues/29948#issuecomment-1163905512)
+            query = Request.Query[nameof(query)];
+
             string result = null;
             try
             {

--- a/src/QuickInfoWeb/QuickInfoWeb.csproj
+++ b/src/QuickInfoWeb/QuickInfoWeb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DefaultNamespace>QuickInfo</DefaultNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
This works around the fact that MVC [parameters binding removes whitespace][1].

[1]: https://github.com/dotnet/aspnetcore/issues/29948