### PR TITLE
Fix decoding from bytes

### DIFF
--- a/src/QuickInfo.Tests/IntegrationTests.cs
+++ b/src/QuickInfo.Tests/IntegrationTests.cs
@@ -10,6 +10,7 @@ namespace QuickInfo.Tests
         [InlineData("a",         @"<div class=""mainAnswerText"">LATIN SMALL LETTER A</div>")]
         [InlineData("%C3%A9",    @"<div class=""mainAnswerText"">LATIN SMALL LETTER E WITH ACUTE</div>")]
         [InlineData("%E2%80%AF", @"<div class=""mainAnswerText"">NARROW NO-BREAK SPACE</div>")]
+        [InlineData("F0 9F 8D 92 F0 9F 8D 87", @"🍒🍇")]
         public async Task TestQuery(string query, string output)
         {
             await using var application = new WebApplicationFactory<Program>();

--- a/src/QuickInfo/Query/StructureParser.cs
+++ b/src/QuickInfo/Query/StructureParser.cs
@@ -64,7 +64,7 @@ namespace QuickInfo
                 if (separatedList != null)
                 {
                     var byteList = separatedList.GetStructuresOfType<Integer>();
-                    if (byteList.Count == separatedList.Count && byteList.All(b => b.Value >= 0 && b.Value <= 255))
+                    if (byteList.Count == separatedList.Count && byteList.All(b => b.Value >= -128 && b.Value <= 127))
                     {
                         List<byte> result = new List<byte>();
                         foreach (var b in byteList)


### PR DESCRIPTION
Integer is backed by a signed type so comparison must be done over [-128, 127] instead of [0, 255]

Fixes #58