### PR TITLE
Fix OverflowException

### DIFF
--- a/src/QuickInfo/Processors/ErrorCodeProcessorBase.cs
+++ b/src/QuickInfo/Processors/ErrorCodeProcessorBase.cs
@@ -30,7 +30,7 @@ namespace QuickInfo
         private (string Name, string Description) LookUpInternal(Query query)
         {
             var structure = query.TryGetStructure<Integer>();
-            if (structure != null && Lookup.ContainsKey(structure.Int32))
+            if (structure != null && structure.Value >= int.MinValue && structure.Value <= int.MaxValue && Lookup.ContainsKey(structure.Int32))
             {
                 return Lookup[structure.Int32];
             }


### PR DESCRIPTION
Would happen when entering a too large integer to fit an int.
> System.OverflowException: Value was either too large or too small for an Int32.
   at System.Numerics.BigInteger.op_Explicit(BigInteger value)
   at QuickInfo.Integer.get_Int32() in D:\a\QuickInfo\QuickInfo\src\QuickInfo\Query\Structure\Integer.cs:line 16
   at QuickInfo.ErrorCodeProcessorBase.LookUpInternal(Query query) in D:\a\QuickInfo\QuickInfo\src\QuickInfo\Processors\ErrorCodeProcessorBase.cs:line 33
   at QuickInfo.ErrorCodeProcessorBase.GetResult(Query query) in D:\a\QuickInfo\QuickInfo\src\QuickInfo\Processors\ErrorCodeProcessorBase.cs:line 20
   at QuickInfo.Engine.GetResults(Query query) in D:\a\QuickInfo\QuickInfo\src\QuickInfo\Engine.cs:line 55
   at QuickInfo.Controllers.AnswersController.GetSingleResponseWorker(Engine engine, String input, HttpRequest request) in D:\a\QuickInfo\QuickInfo\src\QuickInfoWeb\Controllers\AnswersController.cs:line 105
   at QuickInfo.Controllers.AnswersController.GetResponse(Engine engine, String input, HttpRequest request) in D:\a\QuickInfo\QuickInfo\src\QuickInfoWeb\Controllers\AnswersController.cs:line 96
   at QuickInfo.Controllers.AnswersController.Get(String query) in D:\a\QuickInfo\QuickInfo\src\QuickInfoWeb\Controllers\AnswersController.cs:line 23