### PR TITLE
Properly handle all unicode scalars

### DIFF
--- a/src/QuickInfo.Tests/IntegrationTests.cs
+++ b/src/QuickInfo.Tests/IntegrationTests.cs
@@ -10,6 +10,7 @@ namespace QuickInfo.Tests
         [InlineData("a",         @"<div class=""mainAnswerText"">LATIN SMALL LETTER A</div>")]
         [InlineData("%C3%A9",    @"<div class=""mainAnswerText"">LATIN SMALL LETTER E WITH ACUTE</div>")]
         [InlineData("%E2%80%AF", @"<div class=""mainAnswerText"">NARROW NO-BREAK SPACE</div>")]
+        [InlineData("U%2BA7FB",  @"<div class=""mainAnswerText"">LATIN EPIGRAPHIC LETTER REVERSED F</div>")]
         [InlineData("F0 9F 8D 92 F0 9F 8D 87", @"🍒🍇")]
         public async Task TestQuery(string query, string output)
         {

--- a/src/QuickInfo/Query/StructureParser.cs
+++ b/src/QuickInfo/Query/StructureParser.cs
@@ -64,7 +64,7 @@ namespace QuickInfo
                 if (separatedList != null)
                 {
                     var byteList = separatedList.GetStructuresOfType<Integer>();
-                    if (byteList.Count == separatedList.Count && byteList.All(b => b.Value >= -128 && b.Value <= 127))
+                    if (byteList.Count == separatedList.Count && byteList.All(b => b.Value >= 0 && b.Value <= 255))
                     {
                         List<byte> result = new List<byte>();
                         foreach (var b in byteList)

--- a/src/QuickInfo/Utilities/StringUtilities.cs
+++ b/src/QuickInfo/Utilities/StringUtilities.cs
@@ -86,7 +86,9 @@ namespace QuickInfo
 
         public static bool TryParseHex(this string s, out BigInteger result)
         {
-            bool success = BigInteger.TryParse(s, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out result);
+            // Prepend "0" to ensure that the hex string is parsed as a positive number
+            // See https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger#working-with-byte-arrays-and-hexadecimal-strings
+            bool success = BigInteger.TryParse("0" + s, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out result);
             return success;
         }
 


### PR DESCRIPTION
Parsing a hexadecimal string as a BigInteger ends up with a negative number if the string starts with 8, 9, A, B, C, D, E or F.

See https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger#working-with-byte-arrays-and-hexadecimal-strings

> To differentiate positive from negative values, positive values should include a leading zero.

Note: this is also related to commit 51fa3784e6d002bd20a2ff060dfc02f0fc2f8a60